### PR TITLE
aes-kw: `no_std` support + other cleanups

### DIFF
--- a/.github/workflows/aes-kw.yml
+++ b/.github/workflows/aes-kw.yml
@@ -17,26 +17,25 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-#  TODO(tarcieri): no_std support  
-#  build:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        rust:
-#          - 1.56.0 # MSRV
-#          - stable
-#        target:
-#          - thumbv7em-none-eabi
-#          - wasm32-unknown-unknown
-#    steps:
-#      - uses: actions/checkout@v1
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: ${{ matrix.rust }}
-#          target: ${{ matrix.target }}
-#          override: true
-#      - run: cargo build --no-default-features --target ${{ matrix.target }}
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.56.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,6 @@ version = "0.0.0"
 dependencies = [
  "aes",
  "generic-array",
- "hex",
  "hex-literal",
 ]
 
@@ -58,12 +57,6 @@ dependencies = [
  "typenum",
  "version_check",
 ]
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 
 [![dependency status][deps-image]][deps-link] ![Apache2/MIT licensed][license-image]
 
-Collection of [Key Wrapping Functions][KW] (KW) written in pure Rust.
+Collection of symmetric [Key Wrapping Functions][KW] (KW) written in pure Rust.
+
+## About
+
+"Key Wraping" describes symmetric encryption algorithms designed for encrypting
+cryptographic key material under another symmetric key, known as a
+"Key-Encrypting-Key" (KEK).
+
+They're intended for applications such as protecting keys while in untrusted
+storage or transmitting keys over untrusted communications networks.
 
 ## Supported Algorithms
 

--- a/aes-kw/Cargo.toml
+++ b/aes-kw/Cargo.toml
@@ -18,7 +18,10 @@ generic-array = "0.14"
 
 [dev-dependencies]
 hex-literal = "0.3"
-hex = "0.4"
+
+[features]
+alloc = []
+std = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aes-kw/README.md
+++ b/aes-kw/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: key-wraps
+# RustCrypto: AES Key Wrap Algorithm
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -6,38 +6,56 @@
 ![Rust Version][rustc-image]
 [![Build Status][build-image]][build-link]
 
-Pure Rust implementation of KW, the [NIST AES-KW Key Wrapping Method](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38F.pdf). Original implementation by @dignifiedquire can be found [here](https://github.com/rpgp/rpgp/blob/master/src/crypto/aes_kw.rs).
+Pure Rust implementation of the [NIST AES-KW Key Wrapping Method] also
+described in [RFC3394].
 
-# Usage
+## About
 
-The most common way to use KW is as follows: you provide the Key Wrapping Key
-and the key-to-be-wrapped, then wrap it, or provide a wrapped-key and unwrap it.
+RFC3394 § 2 describes AES-KW as follows:
 
-```rust
-use aes_kw::Kek;
-use hex_literal::hex;
-use std::{assert_eq, assert};
-use std::convert::TryFrom;
+> The AES key wrap algorithm is designed to wrap or encrypt key data.
+> The key wrap operates on blocks of 64 bits.  Before being wrapped,
+> the key data is parsed into n blocks of 64 bits.
+> 
+> The only restriction the key wrap algorithm places on n is that n be
+> at least two.  (For key data with length less than or equal to 64
+> bits, the constant field used in this specification and the key data
+> form a single 128-bit codebook input making this key wrap
+> unnecessary.)  The key wrap algorithm accommodates all supported AES
+> key sizes.  However, other cryptographic values often need to be
+> wrapped.  One such value is the seed of the random number generator
+> for DSS.  This seed value requires n to be greater than four.
+> Undoubtedly other values require this type of protection. Therefore,
+> no upper bound is imposed on n.
+> 
+> The AES key wrap can be configured to use any of the three key sizes
+> supported by the AES codebook.  The choice of a key size affects the
+> overall security provided by the key wrap, but it does not alter the
+> description of the key wrap algorithm.  Therefore, in the description
+> that follows, the key wrap is described generically; no key size is
+> specified for the KEK.
 
-let kek = Kek::from(hex!("000102030405060708090A0B0C0D0E0F"));
-let input_key = hex!("00112233445566778899AABBCCDDEEFF");
+## Minimum Supported Rust Version
 
-let wrapped_key = kek.wrap(&input_key).unwrap();
-assert_eq!(wrapped_key, hex!("1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5"));
+This crate requires **Rust 1.56** at a minimum.
 
-let unwrapped_key = kek.unwrap(&wrapped_key);
+We may change the MSRV in the future, but it will be accompanied by a minor
+version bump.
 
-match unwrapped_key {
-  Ok(unwrapped_key) => {
-    assert_eq!(unwrapped_key, input_key);
-  }
-  Err(err) => {
-    assert!(false,"Unwrap key failed {:?}", err);
-  }
-}
-```
+## License
 
-Implemented for 128/192/256bit keys.
+Licensed under either of:
+
+- [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
@@ -47,5 +65,10 @@ Implemented for 128/192/256bit keys.
 [docs-link]: https://docs.rs/aes-kw/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
-[build-image]: https://github.com/RustCrypto/key-wraps/workflows/aes-kw/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/key-wraps/actions?query=workflow:aes-kw
+[build-image]: https://github.com/RustCrypto/key-wraps/actions/workflows/aes-kw.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/key-wraps/actions/workflows/aes-kw.yml
+
+[//]: # (links)
+
+[NIST AES-KW Key Wrapping Method]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38F.pdf
+[RFC3394]: https://datatracker.ietf.org/doc/html/rfc3394

--- a/aes-kw/src/error.rs
+++ b/aes-kw/src/error.rs
@@ -1,5 +1,8 @@
 use core::fmt;
 
+/// Result type with the `aes-kw` crate's [`Error`].
+pub type Result<T> = core::result::Result<T, Error>;
+
 /// Errors emitted from the wrap and unwrap operations.
 #[derive(Debug)]
 pub enum Error {
@@ -7,6 +10,11 @@ pub enum Error {
     InvalidDataLength,
     /// Invalid kek size.
     InvalidKekSize(usize),
+    /// Output buffer size invalid.
+    InvalidOutputSize {
+        /// Expected size in bytes.
+        expected: usize,
+    },
     /// Integrity check did not pass.
     IntegrityCheckFailed,
 }
@@ -18,6 +26,9 @@ impl fmt::Display for Error {
             Error::InvalidKekSize(actual_size) => {
                 write!(f, "invalid aes kek size: {}", actual_size)
             }
+            Error::InvalidOutputSize { expected } => {
+                write!(f, "invalid output buffer size: expected {}", expected)
+            }
             Error::IntegrityCheckFailed => {
                 write!(f, "integrity check failed")
             }
@@ -25,4 +36,5 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}

--- a/aes-kw/src/error.rs
+++ b/aes-kw/src/error.rs
@@ -7,14 +7,20 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Debug)]
 pub enum Error {
     /// Input data length invalid.
-    InvalidDataLength,
-    /// Invalid kek size.
-    InvalidKekSize(usize),
+    InvalidDataSize,
+
+    /// Invalid KEK size.
+    InvalidKekSize {
+        /// KEK size provided in bytes (expected 8, 12, or 24).
+        size: usize,
+    },
+
     /// Output buffer size invalid.
     InvalidOutputSize {
         /// Expected size in bytes.
         expected: usize,
     },
+
     /// Integrity check did not pass.
     IntegrityCheckFailed,
 }
@@ -22,9 +28,9 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::InvalidDataLength => write!(f, "data must be a multiple of 64 bits"),
-            Error::InvalidKekSize(actual_size) => {
-                write!(f, "invalid aes kek size: {}", actual_size)
+            Error::InvalidDataSize => write!(f, "data must be a multiple of 64 bits"),
+            Error::InvalidKekSize { size } => {
+                write!(f, "invalid AES KEK size: {}", size)
             }
             Error::InvalidOutputSize { expected } => {
                 write!(f, "invalid output buffer size: expected {}", expected)

--- a/aes-kw/src/kek.rs
+++ b/aes-kw/src/kek.rs
@@ -102,7 +102,7 @@ where
         if value.len() == Aes::KeySize::to_usize() {
             Ok(Kek::new(GenericArray::from_slice(value)))
         } else {
-            Err(Error::InvalidKekSize(value.len() * 8))
+            Err(Error::InvalidKekSize { size: value.len() })
         }
     }
 }
@@ -123,7 +123,7 @@ where
     /// bytes (i.e. 8 bytes) longer than the length of `data`.
     pub fn wrap(&self, data: &[u8], out: &mut [u8]) -> Result<()> {
         if data.len() % SEMIBLOCK_SIZE != 0 {
-            return Err(Error::InvalidDataLength);
+            return Err(Error::InvalidDataSize);
         }
 
         if out.len() != data.len() + IV_LEN {
@@ -185,14 +185,14 @@ where
     /// bytes (i.e. 8 bytes) shorter than the length of `data`.
     pub fn unwrap(&self, data: &[u8], out: &mut [u8]) -> Result<()> {
         if data.len() % SEMIBLOCK_SIZE != 0 {
-            return Err(Error::InvalidDataLength);
+            return Err(Error::InvalidDataSize);
         }
 
         // 0) Prepare inputs
 
         let n = (data.len() / SEMIBLOCK_SIZE)
             .checked_sub(1)
-            .ok_or(Error::InvalidDataLength)?;
+            .ok_or(Error::InvalidDataSize)?;
 
         if out.len() != n * SEMIBLOCK_SIZE {
             return Err(Error::InvalidOutputSize {
@@ -248,7 +248,7 @@ where
         let out_len = data
             .len()
             .checked_sub(IV_LEN)
-            .ok_or(Error::InvalidDataLength)?;
+            .ok_or(Error::InvalidDataSize)?;
 
         let mut out = vec![0u8; out_len];
         self.unwrap(data, &mut out)?;

--- a/aes-kw/src/lib.rs
+++ b/aes-kw/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
@@ -8,8 +9,41 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
+//! # Usage
+//!
+//! The most common way to use KW is as follows: you provide the Key Wrapping Key
+//! and the key-to-be-wrapped, then wrap it, or provide a wrapped-key and unwrap it.
+//!
+//! ```rust
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # #[cfg(feature = "std")]
+//! # {
+//! use aes_kw::Kek;
+//! use hex_literal::hex;
+//!
+//! let kek = Kek::from(hex!("000102030405060708090A0B0C0D0E0F"));
+//! let input_key = hex!("00112233445566778899AABBCCDDEEFF");
+//!
+//! let wrapped_key = kek.wrap_vec(&input_key)?;
+//! assert_eq!(wrapped_key, hex!("1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5"));
+//!
+//! let unwrapped_key = kek.unwrap_vec(&wrapped_key)?;
+//! assert_eq!(unwrapped_key, input_key);
+//! # }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Implemented for 128/192/256bit keys.
+
+#[cfg(feature = "alloc")]
+#[macro_use]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
 mod error;
 mod kek;
 
-pub use error::Error;
-pub use kek::Kek;
+pub use error::{Error, Result};
+pub use kek::{Kek, KekAes128, KekAes192, KekAes256, IV, IV_LEN};

--- a/aes-kw/tests/tests.rs
+++ b/aes-kw/tests/tests.rs
@@ -1,5 +1,5 @@
 use aes_kw::Kek;
-
+use hex_literal::hex;
 use std::assert_eq;
 
 #[cfg(test)]
@@ -10,22 +10,16 @@ mod tests {
         ($name:ident, $kek_typ:ty, $kek:expr, $input:expr, $output:expr) => {
             #[test]
             fn $name() {
-                use std::convert::TryFrom;
+                let kek = Kek::<$kek_typ>::from($kek);
 
-                let kek = Kek::<$kek_typ>::try_from(&hex::decode($kek).unwrap()[..]).unwrap();
-                let input_bin = hex::decode($input).unwrap();
-                let output_bin = hex::decode($output).unwrap();
+                let mut wrapped = [0u8; $output.len()];
+                kek.wrap(&$input, &mut wrapped).unwrap();
 
-                assert_eq!(
-                    hex::encode(kek.wrap(&input_bin).unwrap()),
-                    $output.to_lowercase(),
-                    "failed wrap"
-                );
-                assert_eq!(
-                    hex::encode(kek.unwrap(&output_bin).unwrap()),
-                    $input.to_lowercase(),
-                    "failed unwrap"
-                );
+                let mut unwrapped = [0u8; $input.len()];
+                kek.unwrap(&wrapped, &mut unwrapped).unwrap();
+
+                assert_eq!($output, wrapped, "failed wrap");
+                assert_eq!($input, unwrapped, "failed unwrap");
             }
         };
     }
@@ -33,45 +27,45 @@ mod tests {
     test_aes_kw!(
         wrap_unwrap_128_key_128_kek,
         aes::Aes128,
-        "000102030405060708090A0B0C0D0E0F",
-        "00112233445566778899AABBCCDDEEFF",
-        "1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5"
+        hex!("000102030405060708090A0B0C0D0E0F"),
+        hex!("00112233445566778899AABBCCDDEEFF"),
+        hex!("1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5")
     );
 
     test_aes_kw!(
         wrap_unwrap_128_key_192_kek,
         aes::Aes192,
-        "000102030405060708090A0B0C0D0E0F1011121314151617",
-        "00112233445566778899AABBCCDDEEFF",
-        "96778B25AE6CA435F92B5B97C050AED2468AB8A17AD84E5D"
+        hex!("000102030405060708090A0B0C0D0E0F1011121314151617"),
+        hex!("00112233445566778899AABBCCDDEEFF"),
+        hex!("96778B25AE6CA435F92B5B97C050AED2468AB8A17AD84E5D")
     );
 
     test_aes_kw!(
         wrap_unwrap_128_key_256_kek,
         aes::Aes256,
-        "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
-        "00112233445566778899AABBCCDDEEFF",
-        "64E8C3F9CE0F5BA263E9777905818A2A93C8191E7D6E8AE7"
+        hex!("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"),
+        hex!("00112233445566778899AABBCCDDEEFF"),
+        hex!("64E8C3F9CE0F5BA263E9777905818A2A93C8191E7D6E8AE7")
     );
     test_aes_kw!(
         wrap_unwrap_192_key_192_kek,
         aes::Aes192,
-        "000102030405060708090A0B0C0D0E0F1011121314151617",
-        "00112233445566778899AABBCCDDEEFF0001020304050607",
-        "031D33264E15D33268F24EC260743EDCE1C6C7DDEE725A936BA814915C6762D2"
+        hex!("000102030405060708090A0B0C0D0E0F1011121314151617"),
+        hex!("00112233445566778899AABBCCDDEEFF0001020304050607"),
+        hex!("031D33264E15D33268F24EC260743EDCE1C6C7DDEE725A936BA814915C6762D2")
     );
     test_aes_kw!(
         wrap_unwrap_192_key_256_kek,
         aes::Aes256,
-        "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
-        "00112233445566778899AABBCCDDEEFF0001020304050607",
-        "A8F9BC1612C68B3FF6E6F4FBE30E71E4769C8B80A32CB8958CD5D17D6B254DA1"
+        hex!("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"),
+        hex!("00112233445566778899AABBCCDDEEFF0001020304050607"),
+        hex!("A8F9BC1612C68B3FF6E6F4FBE30E71E4769C8B80A32CB8958CD5D17D6B254DA1")
     );
     test_aes_kw!(
         wrap_unwrap_256_key_256_kek,
         aes::Aes256,
-        "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
-        "00112233445566778899AABBCCDDEEFF000102030405060708090A0B0C0D0E0F",
-        "28C9F404C4B810F4CBCCB35CFB87F8263F5786E2D80ED326CBC7F0E71A99F43BFB988B9B7A02DD21"
+        hex!("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"),
+        hex!("00112233445566778899AABBCCDDEEFF000102030405060708090A0B0C0D0E0F"),
+        hex!("28C9F404C4B810F4CBCCB35CFB87F8263F5786E2D80ED326CBC7F0E71A99F43BFB988B9B7A02DD21")
     );
 }


### PR DESCRIPTION
- Makes the `Kek::{wrap, unwrap}` functions take an output buffer rather than allocating a `Vec<u8>`, allowing them to be used in heapless `no_std` contexts.
- Adds an `alloc` feature along with `Kek::{wrap_vec, unwrap_vec}` functions which provided the previous API.
- Adds convenience `KekAes128`/`KekAes192`/`KekAes256` type aliases.
- Makes the `IV` and `IV_LEN` constants public.
- Removes the use of `hex` for test vectors replacing it with `hex-literal` instead.
- Improves README.md and rustdoc documentation.