### PR TITLE
aes-kw v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "aes-kw"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes",
  "hex-literal",

--- a/aes-kw/CHANGELOG.md
+++ b/aes-kw/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2022-04-20)
+### Changed
+- Use `encrypt_with_backend`/`decrypt_with_backend` methods ([#19])
+
+[#19]: https://github.com/RustCrypto/key-wraps/pull/19
+
 ## 0.2.0 (2022-02-10)
+### Changed
 - Bump `aes` dependency to v0.8 ([#14])
 
 [#14]: https://github.com/RustCrypto/key-wraps/pull/14

--- a/aes-kw/Cargo.toml
+++ b/aes-kw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-kw"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.1"
 description = "NIST 800-38F AES Key Wrap (KW) and Key Wrap with Padding (KWP) modes"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/aes-kw/src/lib.rs
+++ b/aes-kw/src/lib.rs
@@ -2,8 +2,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/aes-kw/0.2.0"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### Changed
- Use `encrypt_with_backend`/`decrypt_with_backend` methods ([#19])

[#19]: https://github.com/RustCrypto/key-wraps/pull/19