### PR TITLE
aes-kw: restore `wrap_vec` and `unwrap_vec`

### DIFF
--- a/aes-kw/Cargo.toml
+++ b/aes-kw/Cargo.toml
@@ -21,7 +21,9 @@ const-oid = { version = "0.10.0-rc.3", optional = true }
 hex-literal = "0.3"
 
 [features]
-default = ["oid"]
+default = ["std", "oid"]
+alloc = []
+std = ["alloc"]
 oid = ["dep:const-oid"]
 
 [package.metadata.docs.rs]

--- a/aes-kw/src/lib.rs
+++ b/aes-kw/src/lib.rs
@@ -8,6 +8,10 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
+#[cfg(feature = "alloc")]
+#[macro_use]
+extern crate alloc;
+
 #[cfg(feature = "oid")]
 mod oid;
 


### PR DESCRIPTION
In the code refactor (#40), the `wrap_vec` and `unwrap_vec` methods got dropped.
Those are convenient to use in std context as you don't need to take care of the size of the buffers.