### PR TITLE
aes-kw: adds `IV` alias type for creating buffers

### DIFF
--- a/aes-kw/src/lib.rs
+++ b/aes-kw/src/lib.rs
@@ -24,6 +24,8 @@ pub use aes;
 pub use aes::cipher;
 pub use aes::cipher::{crypto_common::InnerInit, KeyInit};
 
+use aes::cipher::{consts::U8, typenum::Unsigned};
+
 /// AES-128 key wrapping
 pub type KwAes128 = AesKw<aes::Aes128>;
 /// AES-192 key wrapping
@@ -43,7 +45,10 @@ pub type KwpAes256 = AesKwp<aes::Aes256>;
 /// From NIST SP 800-38F § 4.1:
 ///
 /// > semiblock: given a block cipher, a bit string whose length is half of the block size.
-pub const SEMIBLOCK_SIZE: usize = 8;
+pub const SEMIBLOCK_SIZE: usize = IV::USIZE;
 
 /// Size of an AES-KW and AES-KWP initialization vector in bytes.
 pub const IV_LEN: usize = SEMIBLOCK_SIZE;
+
+/// Size of an AES-KW and AES-KWP initialization vector in bytes.
+pub type IV = U8;


### PR DESCRIPTION
This introduces an `aes_kw::IV` type alias to create buffers for wrapped keys:
```rust
let mut buf = Array::<u8, Sum<<Aes128 as KeySizeUser>::KeySize, aes_kw::IV>>::default();
```