### PR TITLE
belt-block: add fixed size methods

### DIFF
--- a/belt-kwp/README.md
+++ b/belt-kwp/README.md
@@ -33,13 +33,21 @@ let y: [u8; 48] = hex!(
 
 let mut buf = [0u8; 48];
 
-let kw = belt_kwp::BeltKwp::new(&(k.into()));
+let kw = belt_kwp::BeltKwp::new(&k.into());
 
 let wrapped_key = kw.wrap_key(&x, &i, &mut buf).unwrap();
-assert_eq!(y, wrapped_key);
+assert_eq!(wrapped_key, y);
 
 let unwrapped_key = kw.unwrap_key(&y, &i, &mut buf).unwrap();
-assert_eq!(x, unwrapped_key);
+assert_eq!(unwrapped_key, x);
+
+// If key size is known at compile time, you can use the fixed methods:
+use belt_kwp::cipher::consts::U32;
+
+let wrapped_key = kw.wrap_fixed_key::<U32>(&x.into(), &i);
+assert_eq!(wrapped_key, y);
+let unwrapped_key = kw.unwrap_fixed_key::<U32>(&wrapped_key, &i).unwrap();
+assert_eq!(unwrapped_key, x);
 ```
 
 ## Minimum Supported Rust Version

--- a/belt-kwp/tests/mod.rs
+++ b/belt-kwp/tests/mod.rs
@@ -1,6 +1,6 @@
 //! Test vectors from STB 4.101.31-2020 (section A.10, tables A.21-A.22):
 //! https://apmi.bsu.by/assets/files/std/belt-spec371.pdf
-use belt_kwp::{BeltKwp, KeyInit};
+use belt_kwp::{cipher::consts::U32, BeltKwp, KeyInit};
 use hex_literal::hex;
 
 #[test]
@@ -24,16 +24,27 @@ fn belt_kwp() {
     );
 
     let mut buf = [0u8; 48];
+    let kw = BeltKwp::new(&k1.into());
 
-    let kw = BeltKwp::new((&k1).into());
     let res = kw.wrap_key(&x1, &i1, &mut buf).unwrap();
     assert_eq!(y1, res);
     let res = kw.unwrap_key(&y1, &i1, &mut buf).unwrap();
     assert_eq!(x1, res);
 
-    let kw = BeltKwp::new((&k2).into());
+    let res = kw.wrap_fixed_key::<U32>(&x1.into(), &i1);
+    assert_eq!(y1, res.0);
+    let res = kw.unwrap_fixed_key::<U32>(&res, &i1).unwrap();
+    assert_eq!(x1, res.0);
+
+    let kw = BeltKwp::new(&k2.into());
+
     let res = kw.wrap_key(&x2, &i2, &mut buf).unwrap();
     assert_eq!(y2, res);
     let res = kw.unwrap_key(&y2, &i2, &mut buf).unwrap();
     assert_eq!(x2, res);
+
+    let res = kw.wrap_fixed_key::<U32>(&x2.into(), &i2);
+    assert_eq!(y2, res.0);
+    let res = kw.unwrap_fixed_key::<U32>(&res, &i2).unwrap();
+    assert_eq!(x2, res.0);
 }


### PR DESCRIPTION
Add `wrap_fixed_key` and `unwrap_fixed_key` methods which work over key sizes known at compile time.

This PR is inspired by #42 and earlier discussions. I will try to implement a similar PR for `aes-kw` a bit later.