### PR TITLE
belt-kwp: replace "magic" `U16` in bounds with `IvLen`

### DIFF
--- a/belt-kwp/src/lib.rs
+++ b/belt-kwp/src/lib.rs
@@ -90,8 +90,8 @@ impl BeltKwp {
     #[inline]
     pub fn wrap_fixed_key<N>(&self, x: &Array<u8, N>, iv: &[u8; IV_LEN]) -> WrappedKey<N>
     where
-        N: ArraySize + Add<U16> + IsGreaterOrEqual<IvLen>,
-        Sum<N, U16>: ArraySize,
+        N: ArraySize + Add<IvLen> + IsGreaterOrEqual<IvLen>,
+        Sum<N, IvLen>: ArraySize,
         GrEq<N, IvLen>: NonZero,
     {
         let mut res = WrappedKey::<N>::default();
@@ -162,8 +162,8 @@ impl BeltKwp {
         iv: &[u8; IV_LEN],
     ) -> Result<Array<u8, N>, IntegrityCheckFailed>
     where
-        N: ArraySize + Add<U16> + IsGreaterOrEqual<IvLen>,
-        Sum<N, U16>: ArraySize,
+        N: ArraySize + Add<IvLen> + IsGreaterOrEqual<IvLen>,
+        Sum<N, IvLen>: ArraySize,
         GrEq<N, IvLen>: NonZero,
     {
         let mut y = y.clone();

--- a/belt-kwp/src/lib.rs
+++ b/belt-kwp/src/lib.rs
@@ -87,6 +87,8 @@ impl BeltKwp {
     ///     [(); N - IV_LEN]: Sized,
     /// { ... }
     /// ```
+    /// but uses [`hybrid_array::Array`][Array] instead of built-in arrays
+    /// to work around current limitations of the const generics system.
     #[inline]
     pub fn wrap_fixed_key<N>(&self, x: &Array<u8, N>, iv: &[u8; IV_LEN]) -> WrappedKey<N>
     where
@@ -155,6 +157,8 @@ impl BeltKwp {
     ///     [(); N - IV_LEN]: Sized,
     /// { ... }
     /// ```
+    /// but uses [`hybrid_array::Array`][Array] instead of built-in arrays
+    /// to work around current limitations of the const generics system.
     #[inline]
     pub fn unwrap_fixed_key<N>(
         &self,


### PR DESCRIPTION
Also improves a bit docs for fixed methods.