### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "aes-kw"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "aes",
  "const-oid",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "belt-kwp"
-version = "0.0.0"
+version = "0.1.0-rc.0"
 dependencies = [
  "belt-block",
  "hex-literal",

--- a/aes-kw/Cargo.toml
+++ b/aes-kw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-kw"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 description = "NIST 800-38F AES Key Wrap (KW) and Key Wrap with Padding (KWP) modes"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/belt-kwp/Cargo.toml
+++ b/belt-kwp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-kwp"
-version = "0.0.0"
+version = "0.1.0-rc.0"
 description = "STB 34.101.30-2020 Key Wrap Algorithm (KWP) implementation using Belt block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases the following:
- `aes-kw` v0.3.0-rc.1
- `belt-kwp` v0.1.0-rc.0