### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,18 +5,18 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
+checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
 dependencies = [
- "cfg-if",
  "cipher",
+ "cpubits",
  "cpufeatures",
 ]
 
 [[package]]
 name = "aes-kw"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "aes",
  "const-oid",
@@ -25,32 +25,26 @@ dependencies = [
 
 [[package]]
 name = "belt-block"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d9cc93a6506887eed92e4e9459c13469eee4ef2b2af305a182ebf53e4d6a3"
+checksum = "0e3b1e9d1ad19c345095575076767febd525013fc5782276a21069901815ea45"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "belt-kwp"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "belt-block",
  "hex-literal",
 ]
 
 [[package]]
-name = "cfg-if"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
 name = "cipher"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d708bac5451350d56398433b19a7889022fa9187df1a769c0edbc3b2c03167"
+checksum = "9002c8edb9b1e21938663da3489c9c4403bba2393997fb2ecbd401386c0e71dc"
 dependencies = [
  "crypto-common",
  "inout",
@@ -63,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b8986f836d4aeb30ccf4c9d3bd562fd716074cfd7fc4a2948359fbd21ed809"
+checksum = "6f8441110cea75afde0b89a8d796e2bc67b23432f5a9566cb15d9d365d91a2b0"
 dependencies = [
  "hybrid-array",
 ]
@@ -88,9 +88,9 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f471e0a81b2f90ffc0cb2f951ae04da57de8baa46fa99112b062a5173a5088d0"
+checksum = "b41fb3dc24fe72c2e3a4685eed55917c2fb228851257f4a8f2d985da9443c3e5"
 dependencies = [
  "typenum",
 ]

--- a/aes-kw/Cargo.toml
+++ b/aes-kw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-kw"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 description = "NIST 800-38F AES Key Wrap (KW) and Key Wrap with Padding (KWP) modes"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-aes = "0.9.0-rc.2"
+aes = "0.9.0-rc.4"
 const-oid = { version = "0.10", optional = true }
 
 [dev-dependencies]

--- a/aes-kw/src/kw.rs
+++ b/aes-kw/src/kw.rs
@@ -4,7 +4,7 @@ use crate::{Error, IV_LEN, IvLen, ctx::Ctx, error::IntegrityCheckFailed};
 use aes::cipher::{
     Array, Block, BlockCipherDecrypt, BlockCipherEncrypt,
     array::ArraySize,
-    crypto_common::{InnerInit, InnerUser},
+    common::{InnerInit, InnerUser},
     typenum::{Mod, NonZero, Sum, U16, Zero},
 };
 

--- a/aes-kw/src/kwp.rs
+++ b/aes-kw/src/kwp.rs
@@ -4,8 +4,8 @@ use crate::{Error, IV_LEN, IntegrityCheckFailed, IvLen, ctx::Ctx};
 use aes::cipher::{
     Array, Block, BlockCipherDecrypt, BlockCipherEncrypt,
     array::ArraySize,
+    common::{InnerInit, InnerUser},
     consts::{B1, U7, U4294967296},
-    crypto_common::{InnerInit, InnerUser},
     typenum::{Add1, IsLess, Le, NonZero, Prod, Quot, Sum, U16},
 };
 

--- a/aes-kw/src/lib.rs
+++ b/aes-kw/src/lib.rs
@@ -24,7 +24,7 @@ pub use kwp::AesKwp;
 
 pub use aes;
 pub use aes::cipher;
-pub use aes::cipher::{KeyInit, crypto_common::InnerInit};
+pub use aes::cipher::{KeyInit, common::InnerInit};
 
 /// AES-128 key wrapping
 pub type KwAes128 = AesKw<aes::Aes128>;

--- a/belt-kwp/Cargo.toml
+++ b/belt-kwp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-kwp"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 description = "STB 34.101.30-2020 Key Wrap Algorithm (KWP) implementation using Belt block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-belt-block = "0.2.0-rc.2"
+belt-block = "0.2.0-rc.3"
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
Updates the following dependencies:
- `aes` v0.9.0-rc.4
- `belt-block` v0.2.0-rc.3
- (vicariously) `cipher` v0.5.0-rc.8

The latter changed the re-export of `crypto-common` from `cipher::crypto_common` to `cipher::common`, which has been updated in `aes-kw`.

Also cuts the following releases:
- `aes-kw` v0.3.0-rc.2
- `belt-kwp` v0.1.0-rc.1