### PR TITLE
Release aes-kw v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "aes-kw"
-version = "0.3.0-rc.2"
+version = "0.3.0"
 dependencies = [
  "aes",
  "const-oid",

--- a/aes-kw/CHANGELOG.md
+++ b/aes-kw/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+## 0.3.0 (2026-04-10)
 ### Added
 - `AssociatedOid` implementations ([#35])
 

--- a/aes-kw/Cargo.toml
+++ b/aes-kw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes-kw"
-version = "0.3.0-rc.2"
+version = "0.3.0"
 description = "NIST 800-38F AES Key Wrap (KW) and Key Wrap with Padding (KWP) modes"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- `AssociatedOid` implementations ([#35])

### Changed
- Bump `aes` dependency to v0.9 ([#34])
- `Kek` type is split into separate `AesKw` and `AesKwp` types ([#40])
- `wrap` and `unwrap` methods now return resulting slice ([#40])
- Edition changed to 2024 and MSRV bumped to 1.85 ([#47])
- Relax MSRV policy and allow MSRV bumps in patch releases

### Removed
- `Kek::new` inherent method in favor of implementing `InnerInit` ([#40])
- `From`/`Into` impls from key into key-wrapper types ([#40])
- `IV`, `KWP_IV_PREFIX`, and `KWP_MAX_LEN` constants ([#40])

[#34]: https://github.com/RustCrypto/key-wraps/pull/34
[#35]: https://github.com/RustCrypto/key-wraps/pull/35
[#40]: https://github.com/RustCrypto/key-wraps/pull/40
[#47]: https://github.com/RustCrypto/key-wraps/pull/47