### PR TITLE
Release belt-kwp v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "belt-kwp"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "belt-block",
  "hex-literal",

--- a/belt-kwp/CHANGELOG.md
+++ b/belt-kwp/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 (2026-04-10)
+Initial release ([#31])
+
+[#31]: https://github.com/RustCrypto/key-wraps/pull/31

--- a/belt-kwp/Cargo.toml
+++ b/belt-kwp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-kwp"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 description = "STB 34.101.30-2020 Key Wrap Algorithm (KWP) implementation using Belt block cipher"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Initial release ([#31])

[#31]: https://github.com/RustCrypto/key-wraps/pull/31